### PR TITLE
Fix multiple hibernate issue

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -1164,7 +1164,7 @@ if $FLOCK -n -x -w 1 8; then
 	i=10;
 	while [ $i -ge 1 ]
 	do
-	    	$FLOCK -x -w 1 9 && lmt_main_function "$@" && break;
+	    	$FLOCK -x -w 1 9 && lmt_load_config "$@" && lmt_main_function "$@" && break;
 		log "VERBOSE" "Couldn't acquire lock on descriptor 9 in lock_retry(). Retrying.... PID is $$\n"
 	    	i=$(( $i - 1 ))
 	done
@@ -1188,6 +1188,7 @@ if $FLOCK -n -x -w 1 9; then
 	$FLOCK -u 8; ## Release the invoc lock;
 	log "VERBOSE" "Prelim lock acquisition on descriptor 9 with pid $$";
 	log "VERBOSE" "Now invoking lmt_main_function with arguments -- $@";
+	lmt_load_config "$@";
 	lmt_main_function "$@";
 else
 	log "VERBOSE" "Couldn't acquire prelim lock on descriptor 9 with pid $$";


### PR DESCRIPTION
Reload config when locks are taken

Issue description:
We are running out of battery, two laptop-mode
instances are run concurrently, they call lmt_load_config() wich set
ON_AC=0.
The first one take locks and run lmt_main_function while the seconds
waits for locks in lock_retry().
The first one calls hibernate.
The laptop is waken with AC plugged.
The first instance exits and release locks
The second one takes locks and run lmt_main_function but still have
ON_AC=0 due to lmt_load_config() before the hibernation
The second one calls hibernate whereas we are on AC and policy says do
not hibernate on AC.
