### PR TITLE
Add script to read/write sysfs attr "enabled"

### DIFF
--- a/usr/share/laptop-mode-tools/module-helpers/sysfs-pci
+++ b/usr/share/laptop-mode-tools/module-helpers/sysfs-pci
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+readDeviceEnabled() {
+    devpath=$1
+
+    file=$devpath/enable
+    [ -f "$devpath/enabled" ] && file=$devpath/enabled
+
+    [ -r $file ] && cat $file
+}
+
+writeDeviceEnabled() {
+    devpath=$1
+    enabled=$2
+
+    file=$devpath/enable
+    [ -f "$devpath/enabled" ] && file=$devpath/enabled
+
+    [ -w $file ] && echo $enabled > $file
+}

--- a/usr/share/laptop-mode-tools/modules/ethernet
+++ b/usr/share/laptop-mode-tools/modules/ethernet
@@ -3,6 +3,8 @@
 # Laptop mode tools module: Ethernet power saving tweaks.
 #
 
+source /usr/share/laptop-mode-tools/module-helpers/sysfs-pci
+
 if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHERNET = xauto ]; then
 
 	# Let's check the binaries firts
@@ -63,32 +65,25 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
                         fi
                 fi
 
-                if ! [ -z $dev_path ] && [ -f $dev_path/enabled ]; then
-                        if [ x$DISABLE_ETHERNET = x1 ]; then
-                                if [ -f $dev_path/enabled ]; then
-                                        echo 0 > $dev_path/enabled 2>/dev/null
-                                        log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
-                                        DISABLED=1
-                                fi
-                        elif [ x$DISABLE_ETHERNET = x0 ]; then
-                                if [ -f $dev_path/enabled ]; then
-                                        echo 1 > $dev_path/enabled 2>/dev/null
-                                        log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
-                                        DISABLED=0
-                                fi
-                        elif [ x$DISABLE_ETHERNET = x2 ]; then
-                                DISABLED=0 # Be safe. :-)
-                        else
-                                DISABLED=0 # Same here. Be safe. :-)
-                                           # For all other cases also, just disable it.
+                if [ x$DISABLE_ETHERNET = x1 ]; then
+                        if [ "$(readDeviceEnabled $dev_path)" = "1" ]; then
+                                writeDeviceEnabled $dev_path 0
+                                log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
+                                DISABLED=1
+                        fi
+                elif [ x$DISABLE_ETHERNET = x0 ]; then
+                        if [ "$(readDeviceEnabled $dev_path)" = "0" ]; then
+                                writeDeviceEnabled $dev_path 1
+                                log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
+                                DISABLED=0
                         fi
                 else
-                        log "VERBOSE" "$DEVICE does not seem to be supporting enable/disable"
+                        DISABLED=0 # Be safe. :-)
                 fi
 
-               if [ x$DISABLED = x1 ]; then
-                       continue
-               fi
+                if [ x$DISABLED = x1 ]; then
+                        continue
+                fi
 
 		# Wakeup-on-LAN handling
 		if [ x$DISABLE_WAKEUP_ON_LAN = x1 ] ; then

--- a/usr/share/laptop-mode-tools/modules/wireless-ipw-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-ipw-power
@@ -8,6 +8,8 @@
 #
 # Original source: http://ubuntuforums.org/showthread.php?t=419772
 
+source /usr/share/laptop-mode-tools/module-helpers/sysfs-pci
+
 if [ x$CONTROL_IPW_POWER = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_IPW_POWER = xauto ]; then
 
 	# Provide defaults for config file settings
@@ -71,9 +73,9 @@ if [ x$CONTROL_IPW_POWER = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_IPW
 				# the driver.
 				LINK_TARGET=`readlink $DEVICE/device/driver`
 				LINK_TARGET=${LINK_TARGET##*/}
-                                ENABLED=`cat $DEVICE/device/enable`
+				ENABLED=$(readDeviceEnabled $DEVICE/device)
 
-				if [ $ENABLED -eq 1 -a "$LINK_TARGET" = "$1" ]; then
+				if [ "$ENABLED" = "1" -a "$LINK_TARGET" = "$1" ]; then
 					# add the interface name to the list
 		    		        WIFI_IFNAMES="$WIFI_IFNAMES ${DEVICE##*/}"
                                 else

--- a/usr/share/laptop-mode-tools/modules/wireless-iwl-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-iwl-power
@@ -9,6 +9,8 @@
 # This script relies upon the name of the driver.
 #
 
+source /usr/share/laptop-mode-tools/module-helpers/sysfs-pci
+
 #
 # Find all the wireless devices using the supplied driver names.
 # Place the interface names on the list WIFI_IFNAMES.
@@ -24,9 +26,9 @@ findWifiIfsByDriver () {
 			# the driver.
 			LINK_TARGET=`readlink $DEVICE/device/driver`
 			LINK_TARGET=${LINK_TARGET##*/}
-			ENABLED=`cat $DEVICE/device/enabled`
+            ENABLED=$(readDeviceEnabled $DEVICE/device)
 			
-			if [ $ENABLED -eq 1 -a "$LINK_TARGET" = "$1" ] ; then
+			if [ "$ENABLED" = "1" -a "$LINK_TARGET" = "$1" ] ; then
 				# add the interface name to the list
 				WIFI_IFNAMES="$WIFI_IFNAMES ${DEVICE##*/}"
                         else


### PR DESCRIPTION
This is a proposal to handle enable and enabled sysfs attribute for linux kernels before and after 3.13. What do you think? It also reduces code complexity of the ethernet module.

–Stefan
