### PR TITLE
pci: support both enable/enabled

### DIFF
--- a/usr/share/laptop-mode-tools/modules/ethernet
+++ b/usr/share/laptop-mode-tools/modules/ethernet
@@ -63,19 +63,24 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
                         fi
                 fi
 
-                if ! [ -z $dev_path ] && [ -f $dev_path/enabled ]; then
+		dev_enable_path=
+                if [ x$dev_path != x ]; then
+			if [ -f $dev_path/enabled ]; then
+				dev_enable_path=$dev_path/enabled
+			elif [ -f $dev_path/enable ]; then
+				dev_enable_path=$dev_path/enable
+			fi
+		fi
+
+                if [ x$dev_enable_path != x ]; then
                         if [ x$DISABLE_ETHERNET = x1 ]; then
-                                if [ -f $dev_path/enabled ]; then
-                                        echo 0 > $dev_path/enabled 2>/dev/null
-                                        log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
-                                        DISABLED=1
-                                fi
+				echo 0 > $dev_enable_path 2>/dev/null
+				log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
+				DISABLED=1
                         elif [ x$DISABLE_ETHERNET = x0 ]; then
-                                if [ -f $dev_path/enabled ]; then
-                                        echo 1 > $dev_path/enabled 2>/dev/null
-                                        log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
-                                        DISABLED=0
-                                fi
+				echo 1 > $dev_enable_path 2>/dev/null
+				log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
+				DISABLED=0
                         elif [ x$DISABLE_ETHERNET = x2 ]; then
                                 DISABLED=0 # Be safe. :-)
                         else

--- a/usr/share/laptop-mode-tools/modules/wireless-ipw-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-ipw-power
@@ -71,7 +71,7 @@ if [ x$CONTROL_IPW_POWER = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_IPW
 				# the driver.
 				LINK_TARGET=`readlink $DEVICE/device/driver`
 				LINK_TARGET=${LINK_TARGET##*/}
-                                ENABLED=`cat $DEVICE/device/enable`
+				ENABLED=`[ -r $DEVICE/device/enabled ] && cat $DEVICE/device/enabled || cat $DEVICE/device/enable`
 
 				if [ $ENABLED -eq 1 -a "$LINK_TARGET" = "$1" ]; then
 					# add the interface name to the list

--- a/usr/share/laptop-mode-tools/modules/wireless-iwl-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-iwl-power
@@ -24,7 +24,7 @@ findWifiIfsByDriver () {
 			# the driver.
 			LINK_TARGET=`readlink $DEVICE/device/driver`
 			LINK_TARGET=${LINK_TARGET##*/}
-			ENABLED=`cat $DEVICE/device/enabled`
+			ENABLED=`[ -r $DEVICE/device/enabled ] && cat $DEVICE/device/enabled || cat $DEVICE/device/enable`
 			
 			if [ $ENABLED -eq 1 -a "$LINK_TARGET" = "$1" ] ; then
 				# add the interface name to the list


### PR DESCRIPTION
Starting with linux kernel 3.13, the sysfs attribute 'enable' for pci
devices was renambed to 'enabled'.

Support the two notations to allow seamless migration.

Signed-off-by: Alon Bar-Lev alon.barlev@gmail.com
