### PR TITLE
Ethernet poweroff

### DIFF
--- a/etc/laptop-mode/conf.d/ethernet.conf
+++ b/etc/laptop-mode/conf.d/ethernet.conf
@@ -60,11 +60,10 @@ ETHERNET_DEVICES="eth0"
 
 
 # In practise, most of the times a user is on battery, she is using the wireless device
-# Under such cases, you might want to disable your ethernet device completely, when
+# Under such cases, you might want to disable your ethernet interface completely, when
 # on battery.
 #
-# NOTE: This feature heavily depends on functionality from the device driver, often disabled,
-# by default. Please consult your driver documentation to ensure you have the feature enabled
-#
-# Set below setting to 1, to disable ethernet device when on battery
-DISABLE_ETHERNET_ON_BATTERY=0
+# Set below setting to 1, to disable ethernet interface when on battery and
+# when no carrier is detected on the interface (e.g., no active cable is
+# plugged in).
+DISABLE_ETHERNET_ON_BATTERY=1

--- a/usr/share/laptop-mode-tools/modules/ethernet
+++ b/usr/share/laptop-mode-tools/modules/ethernet
@@ -24,6 +24,13 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 		MIITOOL=/bin/false
 	fi
 
+	if [ -x /bin/ip ]; then
+		IPTOOL=/bin/ip
+	else
+		log "VERBOSE" "ip is not installed"
+		IPTOOL=/bin/false
+	fi
+
 
 	if [ $ON_AC -eq 1 ]; then
 		if [ "$ACTIVATE" -eq 1 ]; then
@@ -52,48 +59,7 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 	fi
 
 	for DEVICE in $ETHERNET_DEVICES ; do
-		DISABLED=0
-		path=`readlink -f /sys/class/net/$DEVICE`
-		dev_path=""
-		log "VERBOSE" "ethernet: $path"
-		if ! [ -z $path ]; then
-			if [ -d $path/device ]; then
-				dev_path=`readlink -f $path/device`
-				log "VERBOSE" "ethernet: $dev_path"
-			fi
-		fi
-
-		dev_enable_path=
-		if [ x$dev_path != x ]; then
-			if [ -f $dev_path/enabled ]; then
-				dev_enable_path=$dev_path/enabled
-			elif [ -f $dev_path/enable ]; then
-				dev_enable_path=$dev_path/enable
-			fi
-		fi
-
-		if [ x$dev_enable_path != x ]; then
-			if [ x$DISABLE_ETHERNET = x1 ]; then
-				echo 0 > $dev_enable_path 2>/dev/null
-				log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
-				DISABLED=1
-			elif [ x$DISABLE_ETHERNET = x0 ]; then
-				echo 1 > $dev_enable_path 2>/dev/null
-				log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
-				DISABLED=0
-			elif [ x$DISABLE_ETHERNET = x2 ]; then
-				DISABLED=0 # Be safe. :-)
-			else
-				DISABLED=0 # Same here. Be safe. :-)
-				# For all other cases also, just disable it.
-			fi
-		else
-			log "VERBOSE" "$DEVICE does not seem to be supporting enable/disable"
-		fi
-
-		if [ x$DISABLED = x1 ]; then
-			continue
-		fi
+		log "VERBOSE" "ethernet: $DEVICE"
 
 		# Wakeup-on-LAN handling
 		if [ x$DISABLE_WAKEUP_ON_LAN = x1 ] ; then
@@ -157,6 +123,20 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 				log "VERBOSE" "Could not restore speed for $DEVICE"
 			fi
 		fi
+
+		# Shut down interface
+		if [ x$DISABLE_ETHERNET = x1 ]; then
+			if $IPTOOL link show $DEVICE | grep -q NO-CARRIER; then
+				log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
+				$IPTOOL link set dev $DEVICE down
+			else
+				log "VERBOSE" "ethernet: Not disabling ethernet device $DEVICE with active carrier."
+			fi
+		elif [ x$DISABLE_ETHERNET = x0 ]; then
+			$IPTOOL link set dev $DEVICE up
+			log "VERBOSE" "ethernet: Re-enabling ethernet device $DEVICE"
+		fi
+
 	done
 else
 	log "VERBOSE" "Ethernet module is disabled."


### PR DESCRIPTION
The following commit replaces the "echo 0 > enabled" code to disable PCI devices
by "ip link set dev DEV down". The reasons are as follows:
1. The "enabled" sysfs attr for PCI devices is an enabled counter, i.e., a kind
   of reference counter that keeps track of the number of requests to enable a
   device. Writing "0" to it decrements the counter as we can see from
     pci-sysfs.c:enablestore()
     pci.c:disable_device()
   
   Simply writing 0 to enabled may have no effects. Indeed, disabling a disabled
   device provokes a kernel warning, see disable_device(). Hence, we should not
   disable a device which we didn't enable before, which again would not make
   sense for our ultimate goal: powering down the device. If we do "echo 0" to
   an disabled device, we get -EIO returned, see enablestore(). This also
   resolves Issue #21 in github.
2. Even if the device becomes disabled, it does not mean that the device would
   stop draining power. In fact, my e1000e ethernet device drains roughly
   700-800 mW even though the counter became 0. (Actually, enabeling and
   disabeling it frequently makes the kernel unstable. Maybe this is related to
   the fact that we are altering reference counters?)

Using "ip link set dev DEV down" causes my ethernet device (e1000e) to consume 0
mW according to powertop. As a side result, the code becomes much cleaner.
