### PR TITLE
modules: fix grep error on missing $device/uevent

### DIFF
--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -26,7 +26,9 @@ listed_by_type() {
 	device_base=`basename $device`
 	list=$2
 	for driver_type in $list; do
-		if grep -q DRIVER=$driver_type $device/uevent; then
+		# The device could have been removed in the meantime
+		[ -r $device/uevent ] || continue
+		if grep -s -q DRIVER=$driver_type $device/uevent; then
 			return 0
 		fi
 		# Check child devices as well.  The actual driver type is

--- a/usr/share/laptop-mode-tools/modules/usb-autosuspend
+++ b/usr/share/laptop-mode-tools/modules/usb-autosuspend
@@ -26,7 +26,9 @@ listed_by_type() {
 	device_base=`basename $device`
 	list=$2
 	for driver_type in $list; do
-		if grep -q DRIVER=$driver_type $device/uevent; then
+		# The device could have been removed in the meantime
+		[ -r $device/uevent ] || continue
+		if grep -s -q DRIVER=$driver_type $device/uevent; then
 			return 0
 		fi
 		# Check child devices as well.  The actual driver type is


### PR DESCRIPTION
A race at boot time may cause the removal of an USB device by the kernel
between enumerating all devices and individually accessing sysfs uevent
files. As a consequence, grep reports errors on missing files during
boot. Fix this.
