### PR TITLE
Change service type to simple

### DIFF
--- a/etc/systemd/laptop-mode.service
+++ b/etc/systemd/laptop-mode.service
@@ -2,7 +2,7 @@
 Description=Laptop Mode Tools
 
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=yes
 ExecStart=/usr/sbin/laptop_mode init auto
 ExecStop=/usr/sbin/laptop_mode init stop


### PR DESCRIPTION
http://freedesktop.org/wiki/Software/systemd/Optimizations/ quote:
23. The usual housekeeping: get rid of shell-based services (i.e. SysV init scripts), replace them with unit files. Don't make use of Type=forking and ordering dependencies if possible, use socket activation with Type=simple instead. This allows drastically better parallelized start-up for your services. Also, if you cannot use socket activation, at least consider patching your services to support Type=notify in place of Type=forking. Consider making seldom used services activated on-demand (for example, printer services), and start frequently used services already at boot instead of delaying them until they are used.
