### PR TITLE
Avoid throttling mechanism from disabling active ethernet

### DIFF
--- a/usr/share/laptop-mode-tools/modules/ethernet
+++ b/usr/share/laptop-mode-tools/modules/ethernet
@@ -61,6 +61,13 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 	for DEVICE in $ETHERNET_DEVICES ; do
 		log "VERBOSE" "ethernet: $DEVICE"
 
+		# Carrier detection
+		if $IPTOOL link show $DEVICE | grep -q NO-CARRIER; then
+		    carrier=false
+		else
+		    carrier=true
+		fi
+
 		# Wakeup-on-LAN handling
 		if [ x$DISABLE_WAKEUP_ON_LAN = x1 ] ; then
 			ret=`$ETHTOOL -s $DEVICE wol d 2>&1`
@@ -104,7 +111,7 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 		# Handle throttling
 		if [ x$THROTTLE_ETHERNET = x1 ] ; then
 			# Handle Speed Throttling
-			ret=`$ETHTOOL -s $DEVICE speed $THROTTLE_SPEED 2>&1`
+			ret=`$ETHTOOL -s $DEVICE speed $THROTTLE_SPEED autoneg off 2>&1`
 			exit_status=$?;
 			log "VERBOSE" "$ret";
 			if [ $exit_status -eq 0 ]; then
@@ -114,19 +121,19 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 			fi
 		else
 			# Handle Speed Throttling
-			ret=`$ETHTOOL -s $DEVICE speed $MAX_SPEED 2>&1`
+			ret=`$ETHTOOL -s $DEVICE autoneg on 2>&1`
 			exit_status=$?;
 			log "VERBOSE" "$ret";
 			if [ $exit_status -eq 0 ]; then
-				log "VERBOSE" "Restored speed to $MAX_SPEED Mbit for $DEVICE"
+				log "VERBOSE" "Restored auto-negotiation for $DEVICE"
 			else
-				log "VERBOSE" "Could not restore speed for $DEVICE"
+				log "VERBOSE" "Could set auto-negotiation for $DEVICE"
 			fi
 		fi
 
 		# Shut down interface
 		if [ x$DISABLE_ETHERNET = x1 ]; then
-			if $IPTOOL link show $DEVICE | grep -q NO-CARRIER; then
+			if !$carrier; then
 				log "VERBOSE" "ethernet: Disabling ethernet device $DEVICE"
 				$IPTOOL link set dev $DEVICE down
 			else


### PR DESCRIPTION
Hi, I'm using laptop-mode-tools in default configuration on Arch linux, I found a problem with *DISABLE_ETHERNET_ON_BATTERY* option (set to 1), regarding to the comment in the config file it may disable the interface only if cable is not plugged in but it's disabling it even with the active connection.

Reason for this behavior is *xxx_THROTTLE_ETHERNET" option. Even if all 3 speed throttling options are disabled, the script is always touching it via `ethtool`: [ethernet:117](https://github.com/rickysarraf/laptop-mode-tools/blob/8fff5eb2bfdde0fa15d8e7813d2399af78d1f064/usr/share/laptop-mode-tools/modules/ethernet#L117)

:warning: And now, every `ethtool` speed manipulation resolves in temporary down-link (in my case it takes 5s until kernel brings back the link up) and due to this, `ip` gets *NO-CARRIER*. 

Because script is checking the link status just after the speed manipulation ([ethernet:129](https://github.com/rickysarraf/laptop-mode-tools/blob/8fff5eb2bfdde0fa15d8e7813d2399af78d1f064/usr/share/laptop-mode-tools/modules/ethernet#L129)), I've separated the carrier detection higher.

Result: We know the carrier status from earlier and we're just working with $carrier and not doing late detection which can be affected by `ethtool` speed manipulations (if link has been lost for couple of seconds).

Minor changes:
- setting the speed: in my case I'm getting "Cannot advertise speed xxx" error, I found proper syntax with *autoneg [off|on]*, i.e.: `ethtool -s eth0 speed 100 autoneg off`
- restoring the speed: dtto, `ethtool -s eth0 autoneg on`

Cheers