### PR TITLE
Don't log 'status unchanged' messages every minute

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -1043,7 +1043,7 @@ lmt_main_function ()
 	fi
 
 	if [ "$INIT" -eq 0 ] ; then
-		log "MSG" "Laptop mode "
+		log "STATUS" "Laptop mode"
 	fi
 
 	# WAS_ACTIVE is used later on. If there is no /var/run/laptop-mode-tools/state, then
@@ -1055,12 +1055,12 @@ lmt_main_function ()
 		if [ "$WAS_STATE" != "" ] ; then
 			if [ "$WAS_ACTIVE" -eq "$ACTIVATE" -a "$WAS_ON_AC" -eq "$ON_AC" -a "$WAS_ACTIVATE_WITH_POSSIBLE_DATA_LOSS" -eq "$ACTIVATE_WITH_POSSIBLE_DATA_LOSS" -a "$WAS_STATE" = "$STATE" -a "$FORCE" -eq 0 ] ; then
 				if [ "$WAS_ACTIVE" -eq 1 ] ; then
-					log "MSG" "$STATE, active [unchanged]"
+					log "STATUS" "$STATE, active [unchanged]"
 					if [ "$ACTIVATE_WITH_POSSIBLE_DATA_LOSS" -eq 0 ] ; then
-						log "MSG" " (Data-loss sensitive features disabled.)"
+						log "STATUS" " (Data-loss sensitive features disabled.)"
 					fi
 				else
-					log "MSG" "$STATE, not active [unchanged]"
+					log "STATUS" "$STATE, not active [unchanged]"
 				fi
 				exit 0
 			fi


### PR DESCRIPTION
Some laptops (for example HP EliteBooks) send a battery ACPI events
approximately every minute as the battery discharges.

LMT will be called on such event and then usually print a "Laptop mode"
banner and information that its status hasn't changed.

These messages carry little information so let's log them with "STATUS"
level (which don't go to syslog) so they don't fill log files on such
laptops.

"STATUS" level also means that they will still be printed to stdout if
user runs /usr/sbin/laptop_mode manually.

This commit doesn't change anything in case LMT status changed since the
script was last run - these messages are still going to be logged.

Use this opportunity to also remove trailing space in "Laptop mode"
banner.
