### PR TITLE
Added delay to battery status check

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -464,7 +464,8 @@ lmt_load_config ()
 				fi
                         elif [ "$(cat $POWER_SUPPLY/type)" = "Battery" ]; then
 				log "VERBOSE" "Determining power state from status of battery $POWER_SUPPLY."
-                                #INFO: Because there are and will always be br0ken batteries
+				sleep 1; # Wait a moment for things to settle down after a transition
+				#INFO: Because there are and will always be br0ken batteries
 				if [ "$(cat $POWER_SUPPLY/status)" != "Discharging" ]; then
 				        if [ "$(cat $POWER_SUPPLY/status)" = "Unknown" ]; then
                                                 log "ERR" "You have a broken battery. Cannot determine actual state"


### PR DESCRIPTION
This check always jumps the gun on my hardware - ThinkPad x230

Without this delay, LMT reports a broken battery, nearly every time the machine is unplugged.  
 
But that's only because the battery status is a little slower to update than laptop-mode is.  With the delay, it correctly reads the status, "Discharging", every time.