### PR TITLE
 Prefer the current capacity of the battery over the original design …

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -787,19 +787,19 @@ lmt_main_function ()
 						fi
 						log "VERBOSE" "Remaining charge: $REMAINING"
 
-						if [ -f $BATT/charge_full_design ] ; then
-							CAPACITY=$(cat $BATT/charge_full_design)
-						elif [ -f $BATT/energy_full_design ] ; then
-							CAPACITY=$(cat $BATT/energy_full_design)
+						if [ -f $BATT/charge_full ] ; then
+							CAPACITY=$(cat $BATT/charge_full)
+						elif [ -f $BATT/energy_full ] ; then
+							CAPACITY=$(cat $BATT/energy_full)
 						else
 							CAPACITY=0
 						fi
 						if [ -z "$CAPACITY" -o "$CAPACITY" -eq 0 ] ; then
-							log "VERBOSE" "Battery does not report design full charge, using non-design full charge."
-							if [ -f $BATT/charge_full ] ; then
-								CAPACITY=$(cat $BATT/charge_full)
+							log "VERBOSE" "Battery does not report a recent full charge, using original design value instead."
+							if [ -f $BATT/charge_full_design ] ; then
+								CAPACITY=$(cat $BATT/charge_full_design)
 							elif [ -f $BATT/energy_full_design ] ; then
-								CAPACITY=$(cat $BATT/energy_full)
+								CAPACITY=$(cat $BATT/energy_full_design)
 							else
 								CAPACITY=0
 							fi


### PR DESCRIPTION
…capacity when calculating charge levels

The design capacity of the battery is only accurate for the first few days or weeks of a battery's life.  

The current capacity should **always** be preferred over the design capacity in these calculations.  This change causes laptops to actually hibernate AT the percentage you set, rather than above it.

I have applied this change to my /usr/sbin/laptop_mode, and it is working PERFECTLY now.  It hibernates exactly when it should, and reports an accurate, current value for the max charge in logs.