### PR TITLE
Cpuhotplug

### DIFF
--- a/etc/laptop-mode/conf.d/cpuhotplug.conf
+++ b/etc/laptop-mode/conf.d/cpuhotplug.conf
@@ -39,6 +39,7 @@ CONTROL_CPU_HOTPLUG=0
 # 3quarter -> disable 3/4 of available logical CPUs
 #
 # integer -> Set this to a user specific number
+# list of cpu<integer>-s -> Disable specific CPUs. Example: "cpu1 cpu3"
 #
 DISABLE_AVAILABLE_CPU="half"
 

--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -6,34 +6,34 @@
 
 # Determine number cpu cores on machine
 max_available_cpus() {
-    CPU=/sys/devices/system/cpu/present
-    if [ -f $CPU ]; then
-        max_cpu=$(cat $CPU | cut -d '-' -f2)
-        max_cpu=$(expr $max_cpu + 1)
-        echo $max_cpu
-    else
-        echo -1
-    fi
+	CPU=/sys/devices/system/cpu/present
+	if [ -f $CPU ]; then
+		max_cpu=$(cat $CPU | cut -d '-' -f2)
+		max_cpu=$(expr $max_cpu + 1)
+		echo $max_cpu
+	else
+		echo -1
+	fi
 }
 
 
 get_numeric_val() {
-    num_cpu=`max_available_cpus`
+	num_cpu=`max_available_cpus`
 
-    case "$1" in
-        "quarter")
-            disable_cpus=$(echo $num_cpu*1/4 | bc)
-            ;;
-        "half")
-            disable_cpus=$(echo $num_cpu*1/2 | bc)
-            ;;
-        "3quarter")
-            disable_cpus=$(echo $num_cpu*3/4 | bc)
-            ;;
-        [0-9]*)
-            disable_cpus=$1;
-            ;;
-    esac
+	case "$1" in
+		"quarter")
+			disable_cpus=$(echo $num_cpu*1/4 | bc)
+			;;
+		"half")
+			disable_cpus=$(echo $num_cpu*1/2 | bc)
+			;;
+		"3quarter")
+			disable_cpus=$(echo $num_cpu*3/4 | bc)
+			;;
+		[0-9]*)
+			disable_cpus=$1;
+			;;
+	esac
 }
 
 
@@ -55,15 +55,15 @@ if [ x$CONTROL_CPU_HOTPLUG = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_C
 		CPU_VAL=1
 	fi
 
-        counter=0;
-        get_numeric_val $DISABLE_AVAILABLE_CPU
+	counter=0;
+	get_numeric_val $DISABLE_AVAILABLE_CPU
 
 	for THISCPU in /sys/devices/system/cpu/cpu[0-9]* ; do
-                if [ $counter -le $disable_cpus ]; then
-                        counter=$(expr $counter + 1)
-                else
-                        break
-                fi
+		if [ $counter -le $disable_cpus ]; then
+			counter=$(expr $counter + 1)
+		else
+			break
+		fi
 
 		if [ -e "$THISCPU/online" ]; then
 			log "VERBOSE" "Bringing CPU $THISCPU to $ECHO_VAL"

--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -16,22 +16,55 @@ max_available_cpus() {
 	fi
 }
 
+# Get a list of cpus to control from a number of cpus that user wants to
+# disable.
+get_cpus_from_number() {
+	counter=0
+	cpu_list=
 
-get_numeric_val() {
+	for cpu in /sys/devices/system/cpu/cpu[0-9]* ; do
+		if [ $counter -le $1 ]; then
+			counter=$(expr $counter + 1)
+		else
+			break
+		fi
+
+		cpu_list="$cpu_list $cpu"
+	done
+}
+
+# Get a list of cpus from a list of cpu ids. Where each id is of the form
+# cpu<integer>.
+get_cpus_from_ids() {
+	cpu_list=
+
+	for cpu_id in $1 ; do
+		cpu_path="/sys/devices/system/cpu/$cpu_id"
+		if [ -d "$cpu_path" ] ; then
+			cpu_list="$cpu_list $cpu_path"
+		fi
+	done
+}
+
+# Get a list of cpus to control from DISABLE_AVAILABLE_CPU value.
+get_cpus_to_control() {
 	num_cpu=`max_available_cpus`
 
 	case "$1" in
 		"quarter")
-			disable_cpus=$(echo $num_cpu*1/4 | bc)
+			get_cpus_from_number $(echo $num_cpu*1/4 | bc)
 			;;
 		"half")
-			disable_cpus=$(echo $num_cpu*1/2 | bc)
+			get_cpus_from_number $(echo $num_cpu*1/2 | bc)
 			;;
 		"3quarter")
-			disable_cpus=$(echo $num_cpu*3/4 | bc)
+			get_cpus_from_number $(echo $num_cpu*3/4 | bc)
 			;;
 		[0-9]*)
-			disable_cpus=$1;
+			get_cpus_from_number $1
+			;;
+		cpu*)
+			get_cpus_from_ids "$1"
 			;;
 	esac
 }
@@ -55,16 +88,9 @@ if [ x$CONTROL_CPU_HOTPLUG = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_C
 		CPU_VAL=1
 	fi
 
-	counter=0;
-	get_numeric_val $DISABLE_AVAILABLE_CPU
+	get_cpus_to_control "$DISABLE_AVAILABLE_CPU"
 
-	for THISCPU in /sys/devices/system/cpu/cpu[0-9]* ; do
-		if [ $counter -le $disable_cpus ]; then
-			counter=$(expr $counter + 1)
-		else
-			break
-		fi
-
+	for THISCPU in $cpu_list ; do
 		if [ -e "$THISCPU/online" ]; then
 			log "VERBOSE" "Bringing CPU $THISCPU to $ECHO_VAL"
 			echo $CPU_VAL > $THISCPU/online

--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -8,27 +8,27 @@
 max_available_cpus() {
     CPU=/sys/devices/system/cpu/present
     if [ -f $CPU ]; then
-        max_cpu=$(cat $CPU | cut -d '-' -f2);
-        max_cpu=$(expr $max_cpu + 1);
-        echo $max_cpu;
+        max_cpu=$(cat $CPU | cut -d '-' -f2)
+        max_cpu=$(expr $max_cpu + 1)
+        echo $max_cpu
     else
-        echo -1;
+        echo -1
     fi
 }
 
 
 get_numeric_val() {
-    num_cpu=`max_available_cpus`;
+    num_cpu=`max_available_cpus`
 
     case "$1" in
         "quarter")
-            disable_cpus=$(echo $num_cpu*1/4 | bc);
+            disable_cpus=$(echo $num_cpu*1/4 | bc)
             ;;
         "half")
-            disable_cpus=$(echo $num_cpu*1/2 | bc);
+            disable_cpus=$(echo $num_cpu*1/2 | bc)
             ;;
         "3quarter")
-            disable_cpus=$(echo $num_cpu*3/4 | bc);
+            disable_cpus=$(echo $num_cpu*3/4 | bc)
             ;;
         [0-9]*)
             disable_cpus=$1;
@@ -50,9 +50,9 @@ if [ x$CONTROL_CPU_HOTPLUG = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_C
 
 	# To disable the CPU, write 0. So flip it here.
 	if [ x$ECHO_VAL = x1 ]; then
-		CPU_VAL=0;
+		CPU_VAL=0
 	else
-		CPU_VAL=1;
+		CPU_VAL=1
 	fi
 
         counter=0;
@@ -60,16 +60,16 @@ if [ x$CONTROL_CPU_HOTPLUG = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_C
 
 	for THISCPU in /sys/devices/system/cpu/cpu[0-9]* ; do
                 if [ $counter -le $disable_cpus ]; then
-                        counter=$(expr $counter + 1);
+                        counter=$(expr $counter + 1)
                 else
-                        break;
+                        break
                 fi
 
 		if [ -e "$THISCPU/online" ]; then
-			log "VERBOSE" "Bringing CPU $THISCPU to $ECHO_VAL";
-			echo $CPU_VAL > $THISCPU/online;
+			log "VERBOSE" "Bringing CPU $THISCPU to $ECHO_VAL"
+			echo $CPU_VAL > $THISCPU/online
 		else
-			log "VERBOSE" "CPU $THISCPU cannot be hot plugged";
+			log "VERBOSE" "CPU $THISCPU cannot be hot plugged"
 		fi
 	done
 fi


### PR DESCRIPTION
    Per discussion on #63.
    
    When DISABLE_AVAILABLE_CPU value doesn't match any of the existing
    options, it's considered to be a list like "cpu1 cpu3". The cpu prefix
    is needed to avoid overlap with a single integer, which specifies the
    number of cpus to disable.
