### PR TITLE
Fix iw/iwconfig wireless-power bugs

### DIFF
--- a/usr/share/laptop-mode-tools/modules/wireless-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-power
@@ -68,7 +68,7 @@ setPowerSave() {
 		$IW dev $IF set power_save $ONOFF
 	else
 		$IWCONFIG $IF power $ONOFF
-                if [ $ONOFF = "ON" ]; then
+                if [ $ONOFF = "on" ]; then
                     $IWCONFIG $IF txpower auto
                 else
                     $IWCONFIG $IF txpower fixed

--- a/usr/share/laptop-mode-tools/modules/wireless-power
+++ b/usr/share/laptop-mode-tools/modules/wireless-power
@@ -66,11 +66,6 @@ setPowerSave() {
 
 	if [ -n "$IW" ]; then
 		$IW dev $IF set power_save $ONOFF
-                if [ $ONOFF = "ON" ]; then
-                    $IW dev $IF set txpower auto
-                else
-                    $IW dev $IF set txpower fixed
-                fi
 	else
 		$IWCONFIG $IF power $ONOFF
                 if [ $ONOFF = "ON" ]; then


### PR DESCRIPTION
One bug only causes a harmless error log. The other bug prevents iwconfig from using it's power-saving txpower mode.