### PR TITLE
runtime-pm: 3.5× speedup

### DIFF
--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -68,11 +68,8 @@ whitelisted() {
 	return 0
 }
 
-echo_to_file_do() {
-	echo "$1" > "$2"
-}
 echo_to_file() {
-	echo_to_file_do "$1" "$2" 2>&1 | \
+	echo "$1" 2>&1 >"$2" |
 		while read REPLY; do
 			log "VERBOSE" "$REPLY"
 		done

--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -68,12 +68,18 @@ whitelisted() {
 	return 0
 }
 
-echo_to_file() {
-	echo "$1" 2>&1 >"$2" |
-		while read REPLY; do
-			log "VERBOSE" "$REPLY"
-		done
-}
+if $LM_VERBOSE; then
+	echo_to_file() {
+		echo "$1" 2>&1 >"$2" |
+			while read REPLY; do
+				log "VERBOSE" "$REPLY"
+			done
+	}
+else
+	echo_to_file() {
+		echo "$1" > "$2" 2>/dev/null
+	}
+fi
 
 if [ x$CONTROL_RUNTIME_AUTOSUSPEND = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_RUNTIME_AUTOSUSPEND = xauto ]; then
 	if [ $ON_AC -eq 1 ]; then

--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -69,13 +69,13 @@ whitelisted() {
 }
 
 echo_to_file_do() {
-    echo "$1" > "$2"
+	echo "$1" > "$2"
 }
 echo_to_file() {
-    echo_to_file_do "$1" "$2" 2>&1 | \
-        while read REPLY; do
-            log "VERBOSE" "$REPLY"
-        done
+	echo_to_file_do "$1" "$2" 2>&1 | \
+		while read REPLY; do
+			log "VERBOSE" "$REPLY"
+		done
 }
 
 if [ x$CONTROL_RUNTIME_AUTOSUSPEND = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_RUNTIME_AUTOSUSPEND = xauto ]; then

--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -16,23 +16,9 @@ listed_by_id() {
 	idproduct=${idproduct#0x}
 
 	for devid in $list; do
-	    case $devid in
-		    *:*) ;;
-		    *) continue;;
-		esac
-
-		vendor=${devid%:*}
-		product=${devid#*:}
-
-		case $idvendor in
-		    ${vendor})
-			case $idproduct in
-			    ${product})	return 0;;
-			    *) ;;
-			esac
-			;;
-		    *);;
-		esac
+		if [ "$devid" = "$idvendor:$idproduct" ]; then
+			return 0
+		fi
 	done
 	return 1
 }

--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -8,8 +8,8 @@ listed_by_id() {
 	device=$1
 	list=$2
 
-	if ! { idvendor=$(< $device/idVendor ) || idvendor=$(< $device/vendor ); } 2>/dev/null || \
-	   ! { idproduct=$(< $device/idProduct ) || idproduct=$(< $device/device ); } 2>/dev/null; then
+	if ! { read -r idvendor < $device/idVendor || read -r idvendor < $device/vendor; } 2>/dev/null || \
+	   ! { read -r idproduct < $device/idProduct || read -r idproduct < $device/device; } 2>/dev/null; then
 		return 1
 	fi
 	idvendor=${idvendor#0x}
@@ -29,16 +29,16 @@ listed_by_type() {
 	device_base=${device##*/}
 	list=$2
 
-	if ! { uevent_data=$(< $device/uevent ); } 2>/dev/null; then
-		return 1
-	fi
+	[ -r $device/uevent ] || return 1
 
-	for driver_type in $list; do
-		case "$uevent_data" in
-			*DRIVER=$driver_type*) return 0 ;;
-			*DEVTYPE=$driver_type*) return 0 ;;
-		esac
-	done
+	while read -r uevent_data; do
+		for driver_type in $list; do
+			case "$uevent_data" in
+				DRIVER=$driver_type) return 0 ;;
+				DEVTYPE=$driver_type) return 0 ;;
+			esac
+		done
+	done < $device/uevent
 
 	# Check child devices as well.  The actual driver type is
 	# listed in a child device, not the top-level device.

--- a/usr/share/laptop-mode-tools/modules/runtime-pm
+++ b/usr/share/laptop-mode-tools/modules/runtime-pm
@@ -8,8 +8,8 @@ listed_by_id() {
 	device=$1
 	list=$2
 
-	if ! idvendor=$(cat $device/idVendor 2>/dev/null || cat $device/vendor 2>/dev/null) || \
-	   ! idproduct=$(cat $device/idProduct 2>/dev/null || cat $device/device 2>/dev/null); then
+	if ! { idvendor=$(< $device/idVendor ) || idvendor=$(< $device/vendor ); } 2>/dev/null || \
+	   ! { idproduct=$(< $device/idProduct ) || idproduct=$(< $device/device ); } 2>/dev/null; then
 		return 1
 	fi
 	idvendor=${idvendor#0x}
@@ -26,10 +26,10 @@ listed_by_id() {
 # Check whether the driver type is blacklisted
 listed_by_type() {
 	device=$1
-	device_base=`basename $device`
+	device_base=${device##*/}
 	list=$2
 
-	if ! uevent_data=$(cat $device/uevent 2>/dev/null); then
+	if ! { uevent_data=$(< $device/uevent ); } 2>/dev/null; then
 		return 1
 	fi
 


### PR DESCRIPTION
Recent changes in `runtime-pm` have slowed it down to *several seconds*
on current hardware (see individual commits for details), which causes
annoyingly noticeable CPU spikes whenever plugging/unplugging AC power.

Also, I think it happened to me a few times that I resumed a laptop,
typed a few quick words, suspended it again, and managed to do this
before all queued laptop_mode runs finished, so the next time I resumed,
weird things happened. Speeding `runtime-pm` up should make this less
likely. Or those weird things may be entirely unrelated. :-/

Finally, the changes in `echo_to_file` should probably be ported to
`usr/sbin/laptop_mode` and `echo_to_file` dropped from `runtime-pm`, but
there seems to be some unfinished work going on in
`usr/sbin/laptop_mode:echo_to_file`, so I was afraid to touch that. Feel
free to explain what's going on there, I'll try to help if I can.