### PR TITLE
wait for Unknown battery state to change

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -492,20 +492,20 @@ lmt_load_config ()
 				log "VERBOSE" "Determining power state from $POWER_SUPPLY/online."
 				if [ "$(cat $POWER_SUPPLY/online)" = 1 ]; then
 					ON_AC=1
-                                        break
+					break
 				fi
-                        elif [ "$(cat $POWER_SUPPLY/type)" = "Battery" ]; then
+			elif [ "$(cat $POWER_SUPPLY/type)" = "Battery" ]; then
 				log "VERBOSE" "Determining power state from status of battery $POWER_SUPPLY."
-                                #INFO: Because there are and will always be br0ken batteries
+				#INFO: Because there are and will always be br0ken batteries
 				if [ "$(cat $POWER_SUPPLY/status)" != "Discharging" ]; then
-				        if [ "$(cat $POWER_SUPPLY/status)" = "Unknown" ]; then
-                                                log "ERR" "You have a broken battery. Cannot determine actual state"
-                                                log "ERR" "Please report this to the linux-acpi developers"
-                                                log "ERR" "Not determining any state from this device: $POWER_SUPPLY"
-                                        else
-                                                log "VERBOSE" "In Battery state, but battery does not report discharge"
+					if [ "$(cat $POWER_SUPPLY/status)" = "Unknown" ]; then
+						log "ERR" "You have a broken battery. Cannot determine actual state"
+						log "ERR" "Please report this to the linux-acpi developers"
+						log "ERR" "Not determining any state from this device: $POWER_SUPPLY"
+					else
+						log "VERBOSE" "In Battery state, but battery does not report discharge"
 						BATTERY_NOT_DISCHARGING=1
-                                        fi
+					fi
 				else
 					log "VERBOSE" "Marking it as non-AC because there's battery $POWER_SUPPLY in Discharging state"
 					ON_AC=0

--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -496,7 +496,16 @@ lmt_load_config ()
 				fi
 			elif [ "$(cat $POWER_SUPPLY/type)" = "Battery" ]; then
 				log "VERBOSE" "Determining power state from status of battery $POWER_SUPPLY."
-				#INFO: Because there are and will always be br0ken batteries
+
+				# INFO: Because there are and will always be br0ken batteries
+				# Sometimes state will go to 'Unknown' for a brief duration before going
+				# to 'Discharging'.  # This has seen to happen at least with Lenovo batteries
+				RETRY_COUNT=0
+				while [ "$(cat $POWER_SUPPLY/status)" = "Unknown" ] && [ "$RETRY_COUNT" -lt 10 ]; do
+					RETRY_COUNT=$(( RETRY_COUNT + 1 ))
+					sleep 0.1
+				done
+
 				if [ "$(cat $POWER_SUPPLY/status)" != "Discharging" ]; then
 					if [ "$(cat $POWER_SUPPLY/status)" = "Unknown" ]; then
 						log "ERR" "You have a broken battery. Cannot determine actual state"


### PR DESCRIPTION
I started to have issues when I took my Lenovo T530 away from the dock. Disks stopped and I found this from syslog:
```
Dec  9 21:38:37 kaasu systemd[1]: Reloading Laptop Mode Tools.
Dec  9 21:38:37 kaasu laptop-mode: You have a broken battery. Cannot determine actual state
Dec  9 21:38:37 kaasu laptop_mode[8558]: You have a broken battery. Cannot determine actual state
Dec  9 21:38:37 kaasu laptop-mode: Please report this to the linux-acpi developers
Dec  9 21:38:37 kaasu laptop_mode[8558]: Please report this to the linux-acpi developers
Dec  9 21:38:37 kaasu laptop-mode: Not determining any state from this device: /sys/class/power_supply/BAT0
Dec  9 21:38:37 kaasu laptop_mode[8558]: Not determining any state from this device: /sys/class/power_supply/BAT0
Dec  9 21:38:37 kaasu laptop-mode: You have a broken battery. Cannot determine actual state
Dec  9 21:38:37 kaasu laptop_mode[8558]: You have a broken battery. Cannot determine actual state
Dec  9 21:38:37 kaasu laptop-mode: Please report this to the linux-acpi developers
Dec  9 21:38:37 kaasu laptop_mode[8558]: Please report this to the linux-acpi developers
Dec  9 21:38:37 kaasu laptop-mode: Not determining any state from this device: /sys/class/power_supply/BAT0
Dec  9 21:38:37 kaasu laptop_mode[8558]: Not determining any state from this device: /sys/class/power_supply/BAT0
Dec  9 21:38:37 kaasu kernel: [ 1776.950751] thinkpad_acpi: EC reports that Thermal Table has changed
Dec  9 21:38:37 kaasu laptop_mode[8558]: Laptop mode
Dec  9 21:38:37 kaasu laptop-mode: enabled, active
Dec  9 21:38:37 kaasu laptop_mode[8558]: enabled, active
Dec  9 21:38:37 kaasu kernel: [ 1777.046595] sd 0:0:0:0: [sda] Synchronizing SCSI cache
Dec  9 21:38:37 kaasu kernel: [ 1777.046678] sd 1:0:0:0: [sdb] Synchronizing SCSI cache
Dec  9 21:38:37 kaasu kernel: [ 1777.047220] sd 1:0:0:0: [sdb] Stopping disk
Dec  9 21:38:37 kaasu kernel: [ 1777.056981] sd 0:0:0:0: [sda] Stopping disk
```

I checked `/sys/class/power_supply/BAT0/status` and it reported `Discharging`. I googled a little bit around and found similar issues with other Lenovo owners: https://unix.stackexchange.com/questions/203741/lenovo-t440s-battery-status-unknown-but-charging

Decided then to take a look deeper into the `usr/sbin/laptop_mode` and found out my battery goes to `Unknown` state for a brief duration before going to `Discharging`.

This PR adds a wait loop to wait max 1s for the state to change if it sees the battery state as `Unknown`. I don't know how wide-spread this issue is, but at least it fixes my issue and now I'm able to safely take my laptop from dock/charging cable:

```
Dec  9 23:07:18 kaasu systemd[1]: Reloading Laptop Mode Tools.
Dec  9 23:07:19 kaasu laptop-mode: enabled, active
Dec  9 23:07:19 kaasu kernel: [ 3713.045675] EXT4-fs (dm-2): re-mounted. Opts: errors=remount-ro,commit=600
Dec  9 23:07:19 kaasu kernel: [ 3713.056855] EXT4-fs (sda3): re-mounted. Opts: block_validity,barrier,user_xattr,acl
```