### PR TITLE
Fix crash due external battery of mouse

### DIFF
--- a/usr/sbin/laptop_mode
+++ b/usr/sbin/laptop_mode
@@ -756,7 +756,7 @@ checkBattery ()
 				PREV_ENOUGH_CHARGE_TO_PREVENT_HIBERNATION=$ENOUGH_CHARGE_TO_PREVENT_HIBERNATION
 
 				log "VERBOSE" "Checking levels for $BATT."
-				PRESENT=$(cat $BATT/present)
+				PRESENT=$(cat $BATT/present 2> /dev/null || echo "0")
 				log "VERBOSE" "Present: $PRESENT."
 
 				# Only do if the battery is present


### PR DESCRIPTION
I got a crash:
```
Feb 23 09:43:14 neworld laptop_mode[12066]: cat: /sys/class/power_supply/hidpp_battery_0/present: No such file or directory
Feb 23 09:43:14 neworld laptop_mode[12066]: /usr/bin/laptop_mode: line 678: [: : integer expression expected
```

My mouse battery is recognized as `hidpp_battery_0`. Type: `Battery`. However, `present` file does not exist for this battery. For the real battery, file exist and has content `1`. I tested this change on my machine and works well.