### PR TITLE
Use POSIX arithmetic expansions instead of bc.

### DIFF
--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -52,13 +52,13 @@ get_cpus_to_control() {
 
 	case "$1" in
 		"quarter")
-			get_cpus_from_number $(echo $num_cpu*1/4 | bc)
+			get_cpus_from_number $((num_cpu * 1/4))
 			;;
 		"half")
-			get_cpus_from_number $(echo $num_cpu*1/2 | bc)
+			get_cpus_from_number $((num_cpu * 1/2))
 			;;
 		"3quarter")
-			get_cpus_from_number $(echo $num_cpu*3/4 | bc)
+			get_cpus_from_number $((num_cpu * 3/4))
 			;;
 		[0-9]*)
 			get_cpus_from_number $1


### PR DESCRIPTION
This saves the cost of an extra dependency on bc (at least until the need for
more complex calculations arise), which is only ever used here.