### PR TITLE
Fix installation of laptop-mode-tools.svg

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ $INSTALL -d -m 755 "$DESTDIR/etc/laptop-mode/conf.d"
 $INSTALL -d -m 755 "$DESTDIR/etc/laptop-mode/modules"
 $INSTALL -d -m 755 "$DESTDIR/usr/share/polkit-1/actions"
 $INSTALL -d -m 755 "$DESTDIR/usr/share/applications"
-$INSTALL -d -m 755 "$DESTDIR/usr/share/pixmaps"
+$INSTALL -d -m 755 "$DESTDIR/usr/share/icons/hicolor/scalable/apps"
 $INSTALL -d -m 755 "$DESTDIR/usr/sbin"
 $INSTALL -d -m 755 "$DESTDIR/$UDEV_D/rules.d"
 $INSTALL -d -m 755 "$DESTDIR/$MAN_D/man8"
@@ -208,8 +208,8 @@ if ( ! $INSTALL -m 755 gui/lmt-config-gui* "$DESTDIR/usr/sbin" ) ; then
 	exit 11
 fi
 
-if ( ! $INSTALL -m 644 gui/laptop-mode-tools.svg "$DESTDIR/usr/share/pixmaps" ) ; then
-	echo "$0: Failed to install $DESTDIR/usr/share/pixmaps/laptop-mode-tools.svg";
+if ( ! $INSTALL -m 644 gui/laptop-mode-tools.svg "$DESTDIR/usr/share/icons/hicolor/scalable/apps" ) ; then
+	echo "$0: Failed to install $DESTDIR/usr/share/icons/hicolor/scalable/apps/laptop-mode-tools.svg";
 	exit 11
 fi
 

--- a/laptop-mode-tools.spec
+++ b/laptop-mode-tools.spec
@@ -86,7 +86,7 @@ fi
 %{_usr}/share/laptop-mode-tools/lmt.py
 %{_usr}/share/laptop-mode-tools/modules/*
 %{_usr}/share/laptop-mode-tools/module-helpers/*
-%{_usr}/share/pixmaps/laptop-mode-tools.svg
+%{_usr}/share/icons/hicolor/scalable/apps/laptop-mode-tools.svg
 %{_usr}/share/polkit-1/actions/org.linux.lmt.gui.policy
 %{_usr}/lib/pm-utils/sleep.d/*
 %{_usr}/lib/tmpfiles.d/laptop-mode.conf
@@ -97,7 +97,7 @@ fi
 %dir %{_usr}/lib/pm-utils/sleep.d
 %dir %{_usr}/lib/tmpfiles.d
 %dir %{_usr}/share/applications
-%dir %{_usr}/share/pixmaps
+%dir %{_usr}/share/icons/hicolor/scalable/apps
 %dir %{_usr}/share/laptop-mode-tools/modules
 %dir %{_usr}/share/laptop-mode-tools/module-helpers
 %dir %{_sysconfdir}/apm/event.d


### PR DESCRIPTION
It is a scalable icon (SVG), so the "pixmaps" location is definitely
not the right place for it. Instead, install it as part of the XDG
hicolor icon theme.