### PR TITLE
[Debian] Fix installation of laptop-mode-tools.svg

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -56,7 +56,7 @@ install: build
 	install -m755 -d $(DESTDIR)/etc/acpi/actions
 	install -m755 -d $(DESTDIR)/usr/sbin
 	install -m755 -d $(DESTDIR)/usr/share/applications
-	install -m755 -d $(DESTDIR)/usr/share/pixmaps
+	install -m755 -d $(DESTDIR)/usr/share/icons/hicolor/scalable/apps
 	install -m755 -d $(DESTDIR)/usr/share/laptop-mode-tools/modules
 	install -m755 -d $(DESTDIR)/usr/share/laptop-mode-tools/module-helpers
 	install -m755 -d $(DESTDIR)/usr/lib/tmpfiles.d
@@ -98,9 +98,8 @@ install: build
 	install -m755 gui/lmt-config-gui $(DESTDIR)/usr/sbin/lmt-config-gui
 	install -m755 gui/lmt-config-gui-pkexec $(DESTDIR)/usr/sbin/lmt-config-gui-pkexec
 	install -m644 gui/lmt.py $(DESTDIR)/usr/share/laptop-mode-tools/lmt.py
-	install -m644 gui/laptop-mode-tools.svg $(DESTDIR)/usr/share/pixmaps/
+	install -m644 gui/laptop-mode-tools.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/
 	install -m644 gui/laptop-mode-tools.desktop $(DESTDIR)/usr/share/applications/
-	install -m644 gui/laptop-mode-tools.svg $(DESTDIR)/usr/share/pixmaps/
 	install -m644 usr/share/polkit-1/actions/org.linux.lmt.gui.policy $(DESTDIR)/usr/share/polkit-1/actions/
 
 # Build architecture-independent files here.


### PR DESCRIPTION
It is a scalable icon (SVG), so the "pixmaps" location is definitely
not the right place for it. Instead, install it as part of the XDG
hicolor icon theme.

Gbp-Dch: Short