### PR TITLE
[Debian] Drop the unused Debian menu file

### DIFF
--- a/debian/menu
+++ b/debian/menu
@@ -1,4 +1,0 @@
-?package(laptop-mode-tools):\
-        section="Applications/System"\
-        title="Laptop Mode Tools Configuration Tool"\
-        command="/usr/bin/lmt-config-gui"


### PR DESCRIPTION
Apparently it was never installed (or not installed for many many
years); also, since the old Debian menu has been deprecated for 6
years, there is no point to keep this unused file around.

Gbp-Dch: Short