### PR TITLE
Fix the bug of incorrect use of DEVICE variable in ethernet

### DIFF
--- a/usr/share/laptop-mode-tools/modules/ethernet
+++ b/usr/share/laptop-mode-tools/modules/ethernet
@@ -31,55 +31,12 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 		IPTOOL=/bin/false
 	fi
 
-
-	# Determine speed capability of physical device
-	speed=`$MIITOOL -v $DEVICE 2>/dev/null | grep capabilities | tr ' ' '\n' |\
-		sort -n | sed -ne '/^1.*/p' | cut -d "b" -f1`
-	if [ -z "$speed" ]; then
-		speed=0;
-	fi
-	max_s=0;
-	min_s=100000;
-	for s in $speed;
-	do
-		if [ $s -gt $max_s ]; then
-			max_s=$s
-		fi
-		if [ $s -lt $min_s ]; then
-			min_s=$s
-		fi
-	done
-	MAX_SPEED=$max_s;
-
-	case "$THROTTLE_SPEED" in
-		"slowest")
-			THROTTLE_SPEED=$min_s
-			;;
-		"fastest")
-			THROTTLE_SPEED=$max_s
-			;;
-	esac
-
-	# Carrier detection
-	if $IPTOOL link show $DEVICE | grep -q NO-CARRIER; then
-		carrier="false";
-	else
-		carrier="true";
-	fi
-
-
 	# What state we are in
 	if [ $ON_AC -eq 1 ]; then
 		if [ "$ACTIVATE" -eq 1 ]; then
 			THROTTLE_ETHERNET="$LM_AC_THROTTLE_ETHERNET"
 		else
 			THROTTLE_ETHERNET="$NOLM_AC_THROTTLE_ETHERNET"
-		fi
-
-		# One off a case.
-		# So that when  back on AC, we can resume the speed back to MAX.
-		if [ x$THROTTLE_ETHERNET = x0 ]; then
-			THROTTLE_SPEED=$MAX_SPEED;
 		fi
 
 		if [ x$DISABLE_ETHERNET_ON_BATTERY = x1 ]; then
@@ -103,6 +60,47 @@ if [ x$CONTROL_ETHERNET = x1 ] || [ x$ENABLE_AUTO_MODULES = x1 -a x$CONTROL_ETHE
 
 	for DEVICE in $ETHERNET_DEVICES ; do
 		log "VERBOSE" "ethernet: $DEVICE"
+
+		# Determine speed capability of physical device
+		speed=`$MIITOOL -v $DEVICE 2>/dev/null | grep capabilities | tr ' ' '\n' |\
+			sort -n | sed -ne '/^1.*/p' | cut -d "b" -f1`
+		if [ -z "$speed" ]; then
+			speed=0;
+		fi
+		max_s=0;
+		min_s=100000;
+		for s in $speed;
+		do
+			if [ $s -gt $max_s ]; then
+				max_s=$s
+			fi
+			if [ $s -lt $min_s ]; then
+				min_s=$s
+			fi
+		done
+		MAX_SPEED=$max_s;
+
+		case "$THROTTLE_SPEED" in
+			"slowest")
+				THROTTLE_SPEED=$min_s
+				;;
+			"fastest")
+				THROTTLE_SPEED=$max_s
+				;;
+		esac
+
+		# Carrier detection
+		if $IPTOOL link show $DEVICE | grep -q NO-CARRIER; then
+			carrier="false";
+		else
+			carrier="true";
+		fi
+
+		# One off a case.
+		# So that when  back on AC, we can resume the speed back to MAX.
+		if [ $ON_AC -eq 1 -a x$THROTTLE_ETHERNET = x0 ]; then
+			THROTTLE_SPEED=$MAX_SPEED;
+		fi
 
 		# Wakeup-on-LAN handling
 		if [ x$DISABLE_WAKEUP_ON_LAN = x1 ] ; then


### PR DESCRIPTION
Part of the code uses DEVICE before assigning a value to DEVICE, which will cause the condition to be judged incorrectly.
For example, if there is another network card NO-CARRIER, it will cause eth0 to be erroneously disabled.
Move this part of the code after assigning a value to the DEVICE.

Author: xinpeng.wang <wangxinpeng@uniontech.com>