### PR TITLE
Fix restoring filesystem commit interval

### DIFF
--- a/usr/share/laptop-mode-tools/modules/laptop-mode
+++ b/usr/share/laptop-mode-tools/modules/laptop-mode
@@ -73,7 +73,7 @@ replace_numeric_mount_option () {
 	OPTS="$4"
 	PARSEDOPTS="$(remove_numeric_mount_option $OPT $OPTS)"
 
-	if echo ",$REPLACEMENT_OPTS," | grep ",$OPT=[0123456789]+," > /dev/null ; then
+	if echo ",$REPLACEMENT_OPTS," | grep ",$OPT=[0123456789]\+," > /dev/null ; then
 		echo -n "$PARSEDOPTS,$OPT="
 		echo ",$REPLACEMENT_OPTS," | sed \
 		 -e 's/.*,'"$OPT"'=//'	\


### PR DESCRIPTION
grep without "-E" option uses basic regular expressions, where "+" repetition operator needs to be backslashed as "\+", but replace_numeric_mount_option() function in the laptop-mode module used just a plain "+".

This resulted in this function being unable to find a commit interval option in the saved mount options and so substituting it with the default "commit=0" instead.

Due to this mistake any non-default commit interval would get reset to the filesystem-specific default value (as provided by "commit=0") when laptop mode was deactivated (like when the AC supply was plugged).