### PR TITLE
Implement "efficient cores only" on cpuhotplug plugin

### DIFF
--- a/etc/laptop-mode/conf.d/cpuhotplug.conf
+++ b/etc/laptop-mode/conf.d/cpuhotplug.conf
@@ -37,6 +37,7 @@ CONTROL_CPU_HOTPLUG=0
 # half -> disable half of available logical CPUs
 # quarter -> disable 1/4 of available logical CPUs
 # 3quarter -> disable 3/4 of available logical CPUs
+# ecores -> enable only cpu0+cpu1 and Efficient Cores  
 #
 # integer -> Set this to a user specific number
 # list of cpu<integer>-s -> Disable specific CPUs. Example: "cpu1 cpu3"

--- a/etc/laptop-mode/conf.d/cpuhotplug.conf
+++ b/etc/laptop-mode/conf.d/cpuhotplug.conf
@@ -37,7 +37,8 @@ CONTROL_CPU_HOTPLUG=0
 # half -> disable half of available logical CPUs
 # quarter -> disable 1/4 of available logical CPUs
 # 3quarter -> disable 3/4 of available logical CPUs
-# ecores -> enable only cpu0+cpu1 and Efficient Cores  
+# performance > disable all performance CPUs keeping online
+#     only the efficient cores + cpu0 + cpu1
 #
 # integer -> Set this to a user specific number
 # list of cpu<integer>-s -> Disable specific CPUs. Example: "cpu1 cpu3"

--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -46,6 +46,29 @@ get_cpus_from_ids() {
 	done
 }
 
+# Get the lowest max_freq of all cores, to retrieve what are the
+# ecores(efficient cores) and only enable them + cpu0 and cpu1
+get_cpus_from_lower_max_freq(){
+
+  # evaluating if cpuinfo_max_freq exists and
+  # using cpu0 as the sane default lower max_freq
+  if [  -f /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
+    lowest_maxfreq=$(cat /sys/devices/system/cpu/cpu*/cpufreq/cpuinfo_max_freq| sort -u| head -1)
+  else
+    log "VERBOSE" "cpufreq modules not loaded. Can't proceed with finding lowest max frequency"
+  fi
+
+  # playing safe with kernel by not removing the first CPU and it's related HT
+  cpu_list="/sys/devices/system/cpu/cpu0 /sys/devices/system/cpu/cpu1"
+
+  for cpu in /sys/devices/system/cpu/cpu[0-9]* ; do
+    current_freq=$(cat $cpu/cpufreq/cpuinfo_max_freq)
+    if [ $current_freq -eq $lowest_maxfreq ]; then
+      cpu_list="$cpu_list $cpu"
+    fi
+  done
+}
+
 # Get a list of cpus to control from DISABLE_AVAILABLE_CPU value.
 get_cpus_to_control() {
 	num_cpu=`max_available_cpus`
@@ -59,6 +82,9 @@ get_cpus_to_control() {
 			;;
 		"3quarter")
 			get_cpus_from_number $((num_cpu * 3/4))
+			;;
+		"ecores")
+			get_cpus_from_lower_max_freq
 			;;
 		[0-9]*)
 			get_cpus_from_number $1

--- a/usr/share/laptop-mode-tools/modules/cpuhotplug
+++ b/usr/share/laptop-mode-tools/modules/cpuhotplug
@@ -59,12 +59,14 @@ get_cpus_from_lower_max_freq(){
   fi
 
   # playing safe with kernel by not removing the first CPU and it's related HT
-  cpu_list="/sys/devices/system/cpu/cpu0 /sys/devices/system/cpu/cpu1"
+  cpu_list=""
 
   for cpu in /sys/devices/system/cpu/cpu[0-9]* ; do
     current_freq=$(cat $cpu/cpufreq/cpuinfo_max_freq)
-    if [ $current_freq -eq $lowest_maxfreq ]; then
-      cpu_list="$cpu_list $cpu"
+    if [ $current_freq -gt $lowest_maxfreq ]; then
+      if [ $cpu != "/sys/devices/system/cpu/cpu0" ] && [ $cpu != "/sys/devices/system/cpu/cpu1" ]; then
+        cpu_list="$cpu_list $cpu"
+      fi
     fi
   done
 }
@@ -83,7 +85,7 @@ get_cpus_to_control() {
 		"3quarter")
 			get_cpus_from_number $((num_cpu * 3/4))
 			;;
-		"ecores")
+		"performance")
 			get_cpus_from_lower_max_freq
 			;;
 		[0-9]*)


### PR DESCRIPTION
Hello, 

I'm submitting this feature where if `DISABLE_AVAILABLE_CPU="performance"` is set, the cores with higher maximum frequencies(Performance Cores) and their hyperthreading cores will be disabled, keeping only the ones with lower max frequencies(Efficient cores) enabled. To play safe here, I'll not hotplug `cpu0` and `cpu1` since they could be running kernel stuff(and `cpu1` is usually HT of `cpu0`, have to confirm with `lscpu -e`) 

In my case, I have a `Intel Core i7-12650H`, and when this is configured, the only cores enabled on battery will be cpu0, cpu1, cpu12, cpu13, cpu14, cpu15. The last four are Efficient and work at a max of 3.5GHz, while the other cores work at 4.7GHz

Already tested on my laptop and this is what I get when using this setting: 

![ecores](https://github.com/rickysarraf/laptop-mode-tools/assets/11742211/96f9181a-618a-476a-bf26-0aedfbdfb08f)

There are some processors which have cores with Max Boost and have like 3 different max frequencies(4.9, 4.7 and 4.0Ghz for example). This plugin update will only enable the lower max frequency cores, if more than 2 are provided.